### PR TITLE
Don't rsync when no-provision

### DIFF
--- a/lib/vagrant-openstack-cloud-provider/action.rb
+++ b/lib/vagrant-openstack-cloud-provider/action.rb
@@ -89,8 +89,10 @@ module VagrantPlugins
             end
 
             b2.use ConnectOpenStack
-            b2.use Provision
-            b2.use SyncFolders
+            if env[:provision_enabled]
+              b2.use Provision
+              b2.use SyncFolders
+            end
             b2.use SetHostname
             b2.use CreateServer
           end


### PR DESCRIPTION
If --no-provision if specified for the bring_up action there is no reason
to rsync the folders. This action will be done when the provision will
be executed for the specifics boxes. By doing that we can accelerate the
bring_up command.