### PR TITLE
Only skip provision with --no-provision

### DIFF
--- a/lib/vagrant-openstack-cloud-provider/action.rb
+++ b/lib/vagrant-openstack-cloud-provider/action.rb
@@ -89,7 +89,7 @@ module VagrantPlugins
             end
 
             b2.use ConnectOpenStack
-            if env[:provision_enabled]
+            unless env[:provision_enabled] == false
               b2.use Provision
               b2.use SyncFolders
             end


### PR DESCRIPTION
If --no-provision is not specify, the key provision_enabled does
not exist. So in order to skip, it needs to exist and be false.