### PR TITLE
Add support for availability zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ This provider exposes quite a few provider-specific configuration options:
 * `image` - The server image to boot. This can be a string matching the
   exact ID or name of the image, or this can be a regular expression to
   partially match some image.
+* `availability_zone` - The availability zone to use with nova, 
+this allows to choose which zone your instance will exist on.
 * `endpoint` - The keystone authentication URL of your OpenStack installation.
 * `server_name` - The name of the server within the OpenStack Cloud. This
   defaults to the name of the Vagrant machine (via `config.vm.define`), but

--- a/lib/vagrant-openstack-cloud-provider/action/create_server.rb
+++ b/lib/vagrant-openstack-cloud-provider/action/create_server.rb
@@ -64,6 +64,11 @@ module VagrantPlugins
               env[:ui].info("      - #{net['name']}")
             end
           end
+
+          unless config.availability_zone.nil?
+            env[:ui].info(" -- Availability Zone: #{config.availability_zone}")
+          end
+
           env[:ui].info(" -- Name: #{server_name}")
 
           openstack_nics = []
@@ -82,6 +87,10 @@ module VagrantPlugins
             :metadata           => config.metadata,
             :os_scheduler_hints => config.scheduler_hints
           }
+
+          unless config.availability_zone.nil?
+            options[:availability_zone] = config.availability_zone
+          end
 
           if openstack_nics.any?
             options[:nics] = openstack_nics

--- a/lib/vagrant-openstack-cloud-provider/config.rb
+++ b/lib/vagrant-openstack-cloud-provider/config.rb
@@ -94,6 +94,9 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :user_domain_id
 
+      # @return [String]
+      attr_accessor :availability_zone
+
       # Version to use for keystone authentication
       # Not used for now, will be supported in the next version.
       # Known version are 'v2.0', 'v3'
@@ -141,6 +144,7 @@ module VagrantPlugins
         @instance_ssh_timeout = UNSET_VALUE
         @instance_ssh_check_interval = UNSET_VALUE
         @report_progress = UNSET_VALUE
+        @availability_zone = UNSET_VALUE
 
         @project_name = UNSET_VALUE
         @project_id = UNSET_VALUE
@@ -194,6 +198,7 @@ module VagrantPlugins
         @instance_ssh_timeout = 120 if @instance_ssh_timeout == UNSET_VALUE
         @instance_ssh_check_interval = 2 if @instance_ssh_check_interval == UNSET_VALUE
 
+        @availability_zone = nil if @availability_zone == UNSET_VALUE
         @report_progress = true if @report_progress == UNSET_VALUE
       end
 

--- a/spec/vagrant-openstack-cloud-provider/config_spec.rb
+++ b/spec/vagrant-openstack-cloud-provider/config_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe VagrantPlugins::OpenStack::Config do
     it { is_expected.to have_attributes(identity_api_version: nil) }
 
     it { is_expected.to have_attributes(scheduler_hints: {}) }
+    it { is_expected.to have_attributes(availability_zone: nil) }
     it { is_expected.to have_attributes(instance_build_timeout: 120) }
     it { is_expected.to have_attributes(instance_build_status_check_interval: 1) }
     it { is_expected.to have_attributes(instance_ssh_timeout: 120) }
@@ -71,6 +72,7 @@ RSpec.describe VagrantPlugins::OpenStack::Config do
       :user_domain_id,
       :identity_api_version,
       :scheduler_hints,
+      :availability_zone,
       :report_progress].each do |attribute|
       it "should not default #{attribute} if overridden" do
         subject.send("#{attribute}=", "foo")


### PR DESCRIPTION
This is needed to choose which compute node you will boot on.
Not added test to create_server, this is tech debt
we should address soon.

Uses the fog default if the availability zone is not passed, should
not break anything.

Tested locally with and without the availability_zone config.